### PR TITLE
Add meridianBtnClass to uibTimepicker

### DIFF
--- a/dist/ui-bootstrap-tpls.js
+++ b/dist/ui-bootstrap-tpls.js
@@ -6260,6 +6260,7 @@ angular.module('ui.bootstrap.timepicker', [])
   mousewheel: true,
   arrowkeys: true,
   showSpinners: true,
+  meridianBtnClass: 'btn-secondary',
   templateUrl: 'uib/template/timepicker/timepicker.html'
 })
 
@@ -6273,6 +6274,8 @@ angular.module('ui.bootstrap.timepicker', [])
 
   $scope.tabindex = angular.isDefined($attrs.tabindex) ? $attrs.tabindex : 0;
   $element.removeAttr('tabindex');
+
+  $scope.meridianBtnClass = angular.isDefined($attrs.meridianBtnClass) ? $scope.$parent.$eval($attrs.meridianBtnClass) : timepickerConfig.meridianBtnClass;
 
   this.init = function(ngModelCtrl_, inputs) {
     ngModelCtrl = ngModelCtrl_;
@@ -7924,7 +7927,7 @@ angular.module("uib/template/timepicker/timepicker.html", []).run(["$templateCac
     "      <td class=\"form-group uib-time seconds\" ng-class=\"{'has-error': invalidSeconds}\" ng-show=\"showSeconds\">\n" +
     "        <input type=\"text\" placeholder=\"SS\" ng-model=\"seconds\" ng-change=\"updateSeconds()\" class=\"form-control text-center\" ng-readonly=\"readonlyInput\" maxlength=\"2\" tabindex=\"{{::tabindex}}\" ng-disabled=\"noIncrementSeconds()\" ng-blur=\"blur()\">\n" +
     "      </td>\n" +
-    "      <td ng-show=\"showMeridian\" class=\"uib-time am-pm\"><button type=\"button\" ng-class=\"{disabled: noToggleMeridian()}\" class=\"btn btn-secondary text-center\" ng-click=\"toggleMeridian()\" ng-disabled=\"noToggleMeridian()\" tabindex=\"{{::tabindex}}\">{{meridian}}</button></td>\n" +
+    "      <td ng-show=\"showMeridian\" class=\"uib-time am-pm\"><button type=\"button\" ng-class=\"[meridianBtnClass, {disabled: noToggleMeridian()}]\" class=\"btn btn-secondary text-center\" ng-click=\"toggleMeridian()\" ng-disabled=\"noToggleMeridian()\" tabindex=\"{{::tabindex}}\">{{meridian}}</button></td>\n" +
     "    </tr>\n" +
     "    <tr class=\"text-center\" ng-show=\"::showSpinners\">\n" +
     "      <td class=\"uib-decrement hours\">\n" +

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -11,6 +11,7 @@ angular.module('ui.bootstrap.timepicker', [])
   mousewheel: true,
   arrowkeys: true,
   showSpinners: true,
+  meridianBtnClass: 'btn-secondary',
   templateUrl: 'uib/template/timepicker/timepicker.html'
 })
 
@@ -24,6 +25,8 @@ angular.module('ui.bootstrap.timepicker', [])
 
   $scope.tabindex = angular.isDefined($attrs.tabindex) ? $attrs.tabindex : 0;
   $element.removeAttr('tabindex');
+
+  $scope.meridianBtnClass = angular.isDefined($attrs.meridianBtnClass) ? $scope.$parent.$eval($attrs.meridianBtnClass) : timepickerConfig.meridianBtnClass;
 
   this.init = function(ngModelCtrl_, inputs) {
     ngModelCtrl = ngModelCtrl_;

--- a/template/timepicker/timepicker.html
+++ b/template/timepicker/timepicker.html
@@ -38,7 +38,7 @@
       <td class="form-group uib-time seconds" ng-class="{'has-error': invalidSeconds}" ng-show="showSeconds">
         <input type="text" placeholder="SS" ng-model="seconds" ng-change="updateSeconds()" class="form-control text-center" ng-readonly="readonlyInput" maxlength="2" tabindex="{{::tabindex}}" ng-disabled="noIncrementSeconds()" ng-blur="blur()">
       </td>
-      <td ng-show="showMeridian" class="uib-time am-pm"><button type="button" ng-class="{disabled: noToggleMeridian()}" class="btn btn-secondary text-center" ng-click="toggleMeridian()" ng-disabled="noToggleMeridian()" tabindex="{{::tabindex}}">{{meridian}}</button></td>
+      <td ng-show="showMeridian" class="uib-time am-pm"><button type="button" ng-class="[meridianBtnClass, {disabled: noToggleMeridian()}]" class="btn btn-secondary text-center" ng-click="toggleMeridian()" ng-disabled="noToggleMeridian()" tabindex="{{::tabindex}}">{{meridian}}</button></td>
     </tr>
     <tr class="text-center" ng-show="::showSpinners">
       <td class="uib-decrement hours">


### PR DESCRIPTION
**Changes**
- add `meridianBtnClass` to `uibTimepickerConfig`, using the same default class it uses today: `'btn-secondary'`
- update `UibTimepickerController` to allow class to be passed in via attribute `meridian-btn-class` or fall back to Config (which can be set via `<module>.config()`

**Example**
```
<module>.config(["uibTimepickerConfig", function (uibTimepickerConfig) {
    uibTimepickerConfig.meridianBtnClass = 'btn-primary';
});
```