### PR TITLE
Add dismissClick trigger

### DIFF
--- a/dist/ui-bootstrap-tpls.js
+++ b/dist/ui-bootstrap-tpls.js
@@ -5020,6 +5020,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
     'mouseenter': 'mouseleave',
     'click': 'click',
     'outsideClick': 'outsideClick',
+    'dismissClick': 'dismissClick',
     'focus': 'blur',
     'none': ''
   };
@@ -5211,6 +5212,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
             // By default, the tooltip is not open.
             // TODO add ability to start tooltip opened
             ttScope.isOpen = false;
+
+            ttScope.isLoading = false;
 
             function toggleTooltipBind() {
               if (!ttScope.isOpen) {
@@ -5513,6 +5516,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
               triggers.show.forEach(function(trigger) {
                 if (trigger === 'outsideClick') {
                   element.off('click', toggleTooltipBind);
+                } else if (trigger === 'dismissClick') {
+                  element.off('click', hideTooltipBind);
                 } else {
                   element.off(trigger, showTooltipBind);
                   element.off(trigger, toggleTooltipBind);
@@ -5520,7 +5525,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                 element.off('keypress', hideOnEscapeKey);
               });
               triggers.hide.forEach(function(trigger) {
-                if (trigger === 'outsideClick') {
+                if (trigger === 'outsideClick' || trigger === 'dismissClick') {
                   $document.off('click', bodyHideTooltipBind);
                 } else {
                   element.off(trigger, hideTooltipBind);
@@ -5550,6 +5555,9 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                 triggers.show.forEach(function(trigger, idx) {
                   if (trigger === 'outsideClick') {
                     element.on('click', toggleTooltipBind);
+                    $document.on('click', bodyHideTooltipBind);
+                  } else if (trigger === 'dismissClick') {
+                    element.on('click', hideTooltipBind);
                     $document.on('click', bodyHideTooltipBind);
                   } else if (trigger === triggers.hide[idx]) {
                     element.on(trigger, toggleTooltipBind);

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -25,6 +25,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
     'mouseenter': 'mouseleave',
     'click': 'click',
     'outsideClick': 'outsideClick',
+    'dismissClick': 'dismissClick',
     'focus': 'blur',
     'none': ''
   };
@@ -216,6 +217,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
             // By default, the tooltip is not open.
             // TODO add ability to start tooltip opened
             ttScope.isOpen = false;
+
+            ttScope.isLoading = false;
 
             function toggleTooltipBind() {
               if (!ttScope.isOpen) {
@@ -518,6 +521,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
               triggers.show.forEach(function(trigger) {
                 if (trigger === 'outsideClick') {
                   element.off('click', toggleTooltipBind);
+                } else if (trigger === 'dismissClick') {
+                  element.off('click', hideTooltipBind);
                 } else {
                   element.off(trigger, showTooltipBind);
                   element.off(trigger, toggleTooltipBind);
@@ -525,7 +530,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                 element.off('keypress', hideOnEscapeKey);
               });
               triggers.hide.forEach(function(trigger) {
-                if (trigger === 'outsideClick') {
+                if (trigger === 'outsideClick' || trigger === 'dismissClick') {
                   $document.off('click', bodyHideTooltipBind);
                 } else {
                   element.off(trigger, hideTooltipBind);
@@ -555,6 +560,9 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                 triggers.show.forEach(function(trigger, idx) {
                   if (trigger === 'outsideClick') {
                     element.on('click', toggleTooltipBind);
+                    $document.on('click', bodyHideTooltipBind);
+                  } else if (trigger === 'dismissClick') {
+                    element.on('click', hideTooltipBind);
                     $document.on('click', bodyHideTooltipBind);
                   } else if (trigger === triggers.hide[idx]) {
                     element.on(trigger, toggleTooltipBind);


### PR DESCRIPTION
- add new dismissClick functionality
- clicking the trigger element, or the body, will only trigger the "hide" functionality
- "show" functionality is meant to be completed functionally via the is-open binding