### PR TITLE
Datepicker template config

### DIFF
--- a/dist/ui-bootstrap-tpls.js
+++ b/dist/ui-bootstrap-tpls.js
@@ -1433,6 +1433,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
 .constant('uibDatepickerConfig', {
   datepickerMode: 'day',
+  datepickerTemplateUrl: 'uib/template/datepicker/datepicker.html',
   formatDay: 'dd',
   formatMonth: 'MMMM',
   formatYear: 'yyyy',
@@ -2039,10 +2040,10 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   };
 }])
 
-.directive('uibDatepicker', function() {
+.directive('uibDatepicker', ['uibDatepickerConfig', function(uibDatepickerConfig) {
   return {
     templateUrl: function(element, attrs) {
-      return attrs.templateUrl || 'uib/template/datepicker/datepicker.html';
+      return uibDatepickerConfig.datepickerTemplateUrl || attrs.templateUrl || 'uib/template/datepicker/datepicker.html';
     },
     scope: {
       datepickerOptions: '=?'
@@ -2057,7 +2058,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       datepickerCtrl.init(ngModelCtrl);
     }
   };
-})
+}])
 
 .directive('uibDaypicker', function() {
   return {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -6,6 +6,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
 .constant('uibDatepickerConfig', {
   datepickerMode: 'day',
+  datepickerTemplateUrl: 'uib/template/datepicker/datepicker.html',
   formatDay: 'dd',
   formatMonth: 'MMMM',
   formatYear: 'yyyy',
@@ -612,10 +613,10 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   };
 }])
 
-.directive('uibDatepicker', function() {
+.directive('uibDatepicker', ['uibDatepickerConfig', function(uibDatepickerConfig) {
   return {
     templateUrl: function(element, attrs) {
-      return attrs.templateUrl || 'uib/template/datepicker/datepicker.html';
+      return uibDatepickerConfig.datepickerTemplateUrl || attrs.templateUrl || 'uib/template/datepicker/datepicker.html';
     },
     scope: {
       datepickerOptions: '=?'
@@ -630,7 +631,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       datepickerCtrl.init(ngModelCtrl);
     }
   };
-})
+}])
 
 .directive('uibDaypicker', function() {
   return {


### PR DESCRIPTION
**Changes:**
- add `datepickerTemplateUrl` to `uibDatepickerConfig` which can be then be globally overwritten via `<module>.confg()`
- update `uibDatepicker` directive to use `uibDatepickerConfig.datepickerTemplateUrl` as the default, while still allowing specification via `attrs.templateUrl`