### PR TITLE
Cleanup dropdowns on scope destroy

### DIFF
--- a/dist/ui-bootstrap-tpls.js
+++ b/dist/ui-bootstrap-tpls.js
@@ -3728,6 +3728,34 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
       setIsOpen($scope, isOpen);
     }
   });
+
+  scope.$on('$destroy', function() {
+    var appendTo = null,
+      appendToBody = false;
+
+    if (angular.isDefined($attrs.dropdownAppendTo)) {
+      var appendToEl = $parse($attrs.dropdownAppendTo)(scope);
+      if (appendToEl) {
+        appendTo = angular.element(appendToEl);
+      }
+    }
+
+    if (angular.isDefined($attrs.dropdownAppendToBody)) {
+      var appendToBodyValue = $parse($attrs.dropdownAppendToBody)(scope);
+      if (appendToBodyValue !== false) {
+        appendToBody = true;
+      }
+    }
+
+    if (appendToBody && !appendTo) {
+      appendTo = body;
+    }
+
+    var openContainer = appendTo ? appendTo : angular.element($element[0].querySelector("[uib-dropdown-menu]"));
+    var dropdownOpenClass = appendTo ? appendToOpenClass : openClass;
+    openContainer.removeClass(dropdownOpenClass);
+    uibDropdownService.close(scope, $element, appendTo);
+  });
 }])
 
 .directive('uibDropdown', function() {

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -374,6 +374,34 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
       setIsOpen($scope, isOpen);
     }
   });
+
+  scope.$on('$destroy', function() {
+    var appendTo = null,
+      appendToBody = false;
+
+    if (angular.isDefined($attrs.dropdownAppendTo)) {
+      var appendToEl = $parse($attrs.dropdownAppendTo)(scope);
+      if (appendToEl) {
+        appendTo = angular.element(appendToEl);
+      }
+    }
+
+    if (angular.isDefined($attrs.dropdownAppendToBody)) {
+      var appendToBodyValue = $parse($attrs.dropdownAppendToBody)(scope);
+      if (appendToBodyValue !== false) {
+        appendToBody = true;
+      }
+    }
+
+    if (appendToBody && !appendTo) {
+      appendTo = body;
+    }
+
+    var openContainer = appendTo ? appendTo : angular.element($element[0].querySelector("[uib-dropdown-menu]"));
+    var dropdownOpenClass = appendTo ? appendToOpenClass : openClass;
+    openContainer.removeClass(dropdownOpenClass);
+    uibDropdownService.close(scope, $element, appendTo);
+  });
 }])
 
 .directive('uibDropdown', function() {


### PR DESCRIPTION
- add $on 'destroy' to scope for dropdowns, to ensure the openContainer class is cleaned up and the list of opened dropdowns is properly updated (via uibDropdownService)